### PR TITLE
Add an example config file

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -1,0 +1,15 @@
+# Upon starting the program it will create this config.toml file.
+# Read the README.md for more information on the file location.
+username = "me@example.com"
+password = ""
+smtp_server = "smtp.example.com"
+smtp_port = 587
+message = "I'm probably dead, go to Central Park NY under bench #137 you'll find an age-encrypted drive. Password is our favorite music in Pascal case."
+message_warning = "Hey, you haven't checked in for a while. Are you okay?"
+subject = "[URGENT] Something Happened to Me!"
+subject_warning = "[URGENT] You need to check in!"
+to = "someone@example.com"
+from = "me@example.com"
+attachment = "/root/important_file.gpg" # optional
+timer_warning = 1209600 # 2 weeks
+timer_dead_man = 604800 # 1 week


### PR DESCRIPTION
There is a straight forward example in the code [here](https://github.com/storopoli/dead-man-switch/blob/4b30901186667d698467ca2b6e65fb2550672b95/src/config.rs#L54-L66), but I think it is good to have an example file as well