### PR TITLE
Added 2 functionalities: Email list for "To:", reset route to check-in without auth

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -15,3 +15,4 @@ attachment = "/root/important_file.gpg"                                         
 timer_warning = 1209600                                                                                                                                  # 2 weeks
 timer_dead_man = 604800                                                                                                                                  # 1 week
 web_password = "password"
+route_to_reset = "/reset"

--- a/crates/dead-man-switch-web/Cargo.toml
+++ b/crates/dead-man-switch-web/Cargo.toml
@@ -8,7 +8,8 @@ license = "AGPL-3.0-only"
 readme = "../../README.md"
 
 [dependencies]
-dead-man-switch.workspace = true
+# dead-man-switch.workspace = true
+dead-man-switch = { path = "../dead-man-switch" }
 
 zeroize.workspace = true
 

--- a/crates/dead-man-switch-web/Cargo.toml
+++ b/crates/dead-man-switch-web/Cargo.toml
@@ -8,8 +8,7 @@ license = "AGPL-3.0-only"
 readme = "../../README.md"
 
 [dependencies]
-# dead-man-switch.workspace = true
-dead-man-switch = { path = "../dead-man-switch" }
+dead-man-switch.workspace = true
 
 zeroize.workspace = true
 

--- a/crates/dead-man-switch-web/src/main.rs
+++ b/crates/dead-man-switch-web/src/main.rs
@@ -342,7 +342,7 @@ async fn main() -> anyhow::Result<()> {
     });
 
     // Save path for reset without auth
-    let path = &config.route_to_reset.clone();
+    let path_to_reset = &config.route_to_reset.clone();
 
     // Create a new Timer
     let timer = Timer::new(
@@ -372,7 +372,7 @@ async fn main() -> anyhow::Result<()> {
         .route("/dashboard", get(show_dashboard).post(handle_check_in))
         .route("/logout", post(handle_logout))
         .route("/timer", get(timer_data))
-        .route(path, get (handle_reset_without_auth))
+        .route(path_to_reset, get (handle_reset_without_auth))
         .layer(
             ServiceBuilder::new()
                 .layer(HandleErrorLayer::new(|err: BoxError| async move {

--- a/crates/dead-man-switch-web/src/main.rs
+++ b/crates/dead-man-switch-web/src/main.rs
@@ -325,7 +325,7 @@ async fn main() -> anyhow::Result<()> {
     let subscriber = FmtSubscriber::builder()
         // all spans/events with a level higher than TRACE (e.g, debug, info, warn, etc.)
         // will be written to stdout.
-        .with_max_level(Level::WARN)
+        .with_max_level(Level::TRACE)
         .finish();
     subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
 

--- a/crates/dead-man-switch/src/config.rs
+++ b/crates/dead-man-switch/src/config.rs
@@ -52,6 +52,8 @@ pub struct Config {
     pub timer_dead_man: u64,
     /// Web interface password
     pub web_password: String,
+    /// Route to reset without auth
+    pub route_to_reset: String,
 }
 
 impl Default for Config {
@@ -74,6 +76,7 @@ impl Default for Config {
             timer_warning: 60 * 60 * 24 * 14, // 2 weeks
             timer_dead_man: 60 * 60 * 24 * 7, // 1 week
             web_password,
+            route_to_reset: "/reset".to_string(),
         }
     }
 }

--- a/crates/dead-man-switch/src/email.rs
+++ b/crates/dead-man-switch/src/email.rs
@@ -2,7 +2,6 @@
 
 use std::fs;
 use std::io::{Error as IoError, ErrorKind as IoErrorKind};
-// use std::str::FromStr;
 
 use lettre::{
     address::AddressError,
@@ -16,7 +15,6 @@ use lettre::{
         authentication::Credentials,
         client::{Tls, TlsParameters},
     },
-    // Address, 
     Message, SmtpTransport, Transport,
 };
 use thiserror::Error;

--- a/crates/dead-man-switch/src/email.rs
+++ b/crates/dead-man-switch/src/email.rs
@@ -2,7 +2,7 @@
 
 use std::fs;
 use std::io::{Error as IoError, ErrorKind as IoErrorKind};
-use std::str::FromStr;
+// use std::str::FromStr;
 
 use lettre::{
     address::AddressError,
@@ -16,7 +16,8 @@ use lettre::{
         authentication::Credentials,
         client::{Tls, TlsParameters},
     },
-    Address, Message, SmtpTransport, Transport,
+    // Address, 
+    Message, SmtpTransport, Transport,
 };
 use thiserror::Error;
 
@@ -87,13 +88,25 @@ impl Config {
         let from = Mailbox::new(None, self.from.parse()?);
         // Adjust the email to based on the email type
         let to = match email_type {
-            Email::Warning => Address::from_str(&self.from)?,
-            Email::DeadMan => Address::from_str(&self.to)?,
+            Email::Warning => &self.from,
+            Email::DeadMan => &self.to,
         };
-        let to = Mailbox::new(None, to);
+
+        // parse the comma‐separated list into a Vec<Mailbox>
+        let mailboxes: Vec<Mailbox> = to
+        .split(',')
+        .map(str::trim)
+        .map(|addr| addr.parse::<Mailbox>().expect("invalid email address"))
+        .collect();
 
         // Adjust the email builder based on the email type
-        let email_builder = Message::builder().from(from).to(to);
+        let mut email_builder = Message::builder().from(from);
+        
+        // Add recipients
+        for mbox in mailboxes {
+            email_builder = email_builder.to(mbox);
+        }
+        
         let email_builder = match email_type {
             Email::Warning => email_builder.subject(&self.subject_warning),
             Email::DeadMan => email_builder.subject(&self.subject),
@@ -157,12 +170,13 @@ mod tests {
             message_warning: "This is a test warning message".to_string(),
             subject: "Test Subject".to_string(),
             subject_warning: "Test Warning Subject".to_string(),
-            to: "recipient@example.com".to_string(),
+            to: "recipient@example.com, recipient2@example.com".to_string(),
             from: "sender@example.com".to_string(),
             attachment: None,
             timer_warning: 60,
             timer_dead_man: 120,
             web_password: "password".to_string(),
+            route_to_reset: "/reset".to_string(),
         }
     }
 

--- a/crates/dead-man-switch/src/timer.rs
+++ b/crates/dead-man-switch/src/timer.rs
@@ -167,6 +167,7 @@ mod tests {
             timer_warning: 60,
             timer_dead_man: 120,
             web_password: "password".to_string(),
+            route_to_reset: "/reset".to_string(),
         }
     }
 


### PR DESCRIPTION
Added 2 key functionalities:
- Can use a comma-separated list for the "To:" email addresses (in config: to = "address1@example.com, address2@example.com")
- Added a configurable route to reset without auth, by default /reset. That allows to add in the warning email a link to reset with one click, i.e.:
"You haven't checked in for a while, click on "http://example.com:3000/reset"