### PR TITLE
Reset route to include for a one-click check-in

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -551,6 +551,7 @@ dependencies = [
  "axum",
  "axum-extra",
  "bcrypt",
+ "cookie",
  "dead-man-switch",
  "serde",
  "tokio",

--- a/crates/dead-man-switch-web/Cargo.toml
+++ b/crates/dead-man-switch-web/Cargo.toml
@@ -24,6 +24,7 @@ tracing-subscriber = "0.3.19"
 # Auth handling
 axum-extra = { version = "0.10.1", features = ["cookie", "cookie-private"] }
 bcrypt = "0.17.0"
+cookie = "0.18.1"
 
 # Rate limiting
 tower = { version = "0.5.2", features = ["buffer", "limit"] }


### PR DESCRIPTION
Can now check-in by loading the "/reset" route, i.e. "http://example.com/reset".

It does not bypass auth: it works by making the cookie persistent between sessions (max age of 30 days), so if the user does not logout, it can one-click to check-in. 

Use case would be to adjust the notice in message_warning, for example to: "Hey, you haven't checked in for a while. Are you okay?\nCheck-in at http://localhost:3000/reset" (or https://example.com/reset if using a reverse proxy).