### PR TITLE
Fix a security issue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -506,6 +506,7 @@ dependencies = [
  "serde",
  "thiserror 2.0.17",
  "toml",
+ "uuid",
  "zeroize",
 ]
 

--- a/crates/dead-man-switch/Cargo.toml
+++ b/crates/dead-man-switch/Cargo.toml
@@ -16,3 +16,4 @@ lettre = { version = "0.11.18", features = ["rustls-tls", "builder"] }
 mime_guess = "2.0.5"
 chrono.workspace = true
 zeroize.workspace = true
+uuid = { version = "1.19.0", features = ["v4"] }


### PR DESCRIPTION
The default web_password was hardcoded as "password" which poses a significant security risk. Attackers aware of this default could easily gain unauthorized access to instances where users didn't explicitly configure a password.

Changed to generate a cryptographically secure random UUID v4 as the default password when the WEB_PASSWORD environment variable is not set. This ensures each new installation has a unique, strong default password.

Updated tests to compare against the same config instance rather than a new default (which now has a random password each time).