### PR TITLE
Gate crates.io publish on protected refs and reduce job permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,10 @@ jobs:
   cratesio:
     name: Publish Release to Crates.io
     runs-on: ubuntu-latest
+    if: github.ref_protected
     environment: production
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
### Motivation
- Prevent tag-triggered workflows from exposing `CARGO_REGISTRY_TOKEN` when publishing by ensuring the crates.io publish job only runs for protected refs and has minimal permissions.

### Description
- In `.github/workflows/release.yml` the `cratesio` job was modified to add `if: github.ref_protected` and a job-scoped `permissions: contents: read` to limit execution to protected tags and reduce privilege.

### Testing
- Verified changes and committed the YAML edit using `sed`/file inspection, `git diff`, `git commit`, and `nl -ba .github/workflows/release.yml`, and all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f74dc74f008330ae0181fa1deae37b)