### PR TITLE
Fix persisted warning-state downtime handling

### DIFF
--- a/crates/dead-man-switch/src/timer.rs
+++ b/crates/dead-man-switch/src/timer.rs
@@ -197,21 +197,37 @@ pub fn load_or_initialize(config: &Config) -> Result<Timer, TimerError> {
                 Ok(state) => {
                     // persistence file OK - setup timer based on persisted state
                     let wall_elapsed = wall_elapsed(state.last_modified);
+                    let warning_duration = Duration::from_secs(config.timer_warning);
+                    let dead_man_duration = Duration::from_secs(config.timer_dead_man);
+
                     // Build a monotonic start Instant such that
-                    // Instant::now() - start == wall_elapsed,
+                    // Instant::now() - start == effective_elapsed,
                     // but guard against underflow using checked_sub.
                     let now_mono = Instant::now();
-                    let start = match now_mono.checked_sub(wall_elapsed) {
+                    let (timer_type, duration, effective_elapsed) = match state.timer_type {
+                        TimerType::Warning if wall_elapsed >= warning_duration => {
+                            let dead_man_elapsed = wall_elapsed.saturating_sub(warning_duration);
+                            (
+                                TimerType::DeadMan,
+                                dead_man_duration,
+                                dead_man_elapsed.min(dead_man_duration),
+                            )
+                        }
+                        TimerType::Warning => (TimerType::Warning, warning_duration, wall_elapsed),
+                        TimerType::DeadMan => (
+                            TimerType::DeadMan,
+                            dead_man_duration,
+                            wall_elapsed.min(dead_man_duration),
+                        ),
+                    };
+                    let start = match now_mono.checked_sub(effective_elapsed) {
                         Some(s) => s,
                         None => now_mono, // clamp to zero elapsed
                     };
                     let timer = Timer {
-                        timer_type: state.timer_type,
+                        timer_type,
                         start,
-                        duration: match state.timer_type {
-                            TimerType::Warning => Duration::from_secs(config.timer_warning),
-                            TimerType::DeadMan => Duration::from_secs(config.timer_dead_man),
-                        },
+                        duration,
                     };
                     (timer, state)
                 }
@@ -560,13 +576,14 @@ mod tests {
         let config = Config::default();
 
         // Set state for this test
+        let now_wall = system_time_epoch().unwrap().as_secs();
         let existing_state_1 = State {
             timer_type: TimerType::Warning,
-            last_modified: 3,
+            last_modified: now_wall,
         };
         let existing_state_2 = State {
             timer_type: TimerType::DeadMan,
-            last_modified: 4,
+            last_modified: now_wall,
         };
 
         let _guard_1 = TestGuard::new(&existing_state_1);
@@ -584,6 +601,24 @@ mod tests {
 
         // Compare loaded timer against the existing state data that was saved
         assert_eq!(timer.timer_type, existing_state_2.timer_type);
+    }
+
+
+    #[test]
+    fn load_or_initialize_carries_elapsed_warning_time_into_dead_man() {
+        let mut config = Config::default();
+        config.timer_warning = 10;
+        config.timer_dead_man = 5;
+
+        let now_wall = system_time_epoch().unwrap().as_secs();
+        let _guard = TestGuard::new(&State {
+            timer_type: TimerType::Warning,
+            last_modified: now_wall - 20,
+        });
+
+        let timer = load_or_initialize(&config).unwrap();
+        assert_eq!(timer.get_type(), TimerType::DeadMan);
+        assert!(timer.expired());
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Restoring a persisted `Warning` state applied only the wall-clock elapsed time to the Warning phase and then, upon first update, reset the `DeadMan` phase to a fresh full window, discarding overrun time and delaying final delivery after restarts/outages. 
- The change ensures downtime that already exceeded the warning window is carried into the `DeadMan` phase so the system preserves the intended safety/availability semantics across restarts.

### Description
- Adjust `load_or_initialize` in `crates/dead-man-switch/src/timer.rs` to compute `warning_duration` and `dead_man_duration` and derive a per-phase `effective_elapsed` that clamps elapsed time to each phase; when a persisted `Warning` has already overrun `warning_duration`, initialize the timer as `DeadMan` with residual elapsed applied instead of resetting to a fresh start. 
- Rebuild the `Timer` using the resolved `timer_type`, `duration`, and a monotonic `start` computed with `checked_sub(effective_elapsed)` to avoid underflow. 
- Update an existing persisted-state test to use current wall-clock time so it remains stable, and add a regression test `load_or_initialize_carries_elapsed_warning_time_into_dead_man` that verifies a persisted `Warning` state with downtime exceeding both windows restores as an expired `DeadMan` timer.

### Testing
- Ran `cargo test -p dead-man-switch load_or_initialize_with_existing_file`, which passed. 
- Ran `cargo test -p dead-man-switch load_or_initialize_carries_elapsed_warning_time_into_dead_man`, which passed and demonstrates the regression is fixed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f757982f548330a76ebc6f81f94d7e)