### PR TITLE
fix(web): honor configured cookie session lifetime for JWT login

### DIFF
--- a/crates/dead-man-switch-web/src/main.rs
+++ b/crates/dead-man-switch-web/src/main.rs
@@ -366,12 +366,17 @@ async fn handle_login(
     };
 
     if is_valid {
+        let config = state.app_state.config.read().await;
+        let cookie_exp_hours = i64::try_from(config.cookie_exp_days)
+            .unwrap_or(i64::MAX)
+            .saturating_mul(24);
+
         // Create JWT claims
-        let claims = Claims::new("user".to_string(), 24); // 24 hour expiry
+        let claims = Claims::new("user".to_string(), cookie_exp_hours);
 
         match generate_jwt(&state.secret_data.jwt_secret, claims) {
             Ok(token) => {
-                let secure_cookie = create_secure_cookie("jwt", token, 24);
+                let secure_cookie = create_secure_cookie("jwt", token, cookie_exp_hours);
                 let updated_jar = jar.add(secure_cookie);
                 info!("User successfully authenticated");
                 (updated_jar, Redirect::to("/dashboard")).into_response()


### PR DESCRIPTION
### Motivation
- Fix a security regression where the web login path hard-coded a 24-hour JWT and cookie lifetime instead of using the operator-configurable `cookie_exp_days`, which prevented enforcing shorter or non-persistent sessions.

### Description
- Read `config` from `state.app_state.config` in `handle_login` and compute `cookie_exp_hours` from `config.cookie_exp_days` (converted to `i64` and multiplied by 24).
- Use the computed `cookie_exp_hours` for both `Claims::new(..., cookie_exp_hours)` and `create_secure_cookie("jwt", token, cookie_exp_hours)` so JWT expiration and cookie `max-age` are consistent with configuration.

### Testing
- Ran `cargo test -p dead-man-switch-web --tests` and both unit tests (`test_cookie_duration_conversion` and `test_jwt_generation_and_validation`) passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f75644921883309cd47395748ede63)