### PR TITLE
Restore persisted Warning downtime into DeadMan and add regression test

### DIFF
--- a/crates/dead-man-switch/src/timer.rs
+++ b/crates/dead-man-switch/src/timer.rs
@@ -197,21 +197,36 @@ pub fn load_or_initialize(config: &Config) -> Result<Timer, TimerError> {
                 Ok(state) => {
                     // persistence file OK - setup timer based on persisted state
                     let wall_elapsed = wall_elapsed(state.last_modified);
+                    let warning_duration = Duration::from_secs(config.timer_warning);
+                    let dead_man_duration = Duration::from_secs(config.timer_dead_man);
                     // Build a monotonic start Instant such that
-                    // Instant::now() - start == wall_elapsed,
+                    // Instant::now() - start == effective_elapsed,
                     // but guard against underflow using checked_sub.
                     let now_mono = Instant::now();
-                    let start = match now_mono.checked_sub(wall_elapsed) {
+                    let (timer_type, duration, effective_elapsed) = match state.timer_type {
+                        TimerType::Warning if wall_elapsed >= warning_duration => {
+                            let dead_man_elapsed = wall_elapsed.saturating_sub(warning_duration);
+                            (
+                                TimerType::DeadMan,
+                                dead_man_duration,
+                                dead_man_elapsed.min(dead_man_duration),
+                            )
+                        }
+                        TimerType::Warning => (TimerType::Warning, warning_duration, wall_elapsed),
+                        TimerType::DeadMan => (
+                            TimerType::DeadMan,
+                            dead_man_duration,
+                            wall_elapsed.min(dead_man_duration),
+                        ),
+                    };
+                    let start = match now_mono.checked_sub(effective_elapsed) {
                         Some(s) => s,
                         None => now_mono, // clamp to zero elapsed
                     };
                     let timer = Timer {
-                        timer_type: state.timer_type,
+                        timer_type,
                         start,
-                        duration: match state.timer_type {
-                            TimerType::Warning => Duration::from_secs(config.timer_warning),
-                            TimerType::DeadMan => Duration::from_secs(config.timer_dead_man),
-                        },
+                        duration,
                     };
                     (timer, state)
                 }
@@ -560,13 +575,14 @@ mod tests {
         let config = Config::default();
 
         // Set state for this test
+        let now_wall = system_time_epoch().unwrap().as_secs();
         let existing_state_1 = State {
             timer_type: TimerType::Warning,
-            last_modified: 3,
+            last_modified: now_wall,
         };
         let existing_state_2 = State {
             timer_type: TimerType::DeadMan,
-            last_modified: 4,
+            last_modified: now_wall,
         };
 
         let _guard_1 = TestGuard::new(&existing_state_1);
@@ -584,6 +600,23 @@ mod tests {
 
         // Compare loaded timer against the existing state data that was saved
         assert_eq!(timer.timer_type, existing_state_2.timer_type);
+    }
+
+    #[test]
+    fn load_or_initialize_carries_elapsed_warning_time_into_dead_man() {
+        let mut config = Config::default();
+        config.timer_warning = 10;
+        config.timer_dead_man = 5;
+
+        let now_wall = system_time_epoch().unwrap().as_secs();
+        let _guard = TestGuard::new(&State {
+            timer_type: TimerType::Warning,
+            last_modified: now_wall - 20,
+        });
+
+        let timer = load_or_initialize(&config).unwrap();
+        assert_eq!(timer.get_type(), TimerType::DeadMan);
+        assert!(timer.expired());
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Fix a logic bug where loading a persisted `Warning` state applied wall-clock downtime only to the `Warning` phase and then reset `DeadMan` to a fresh start, allowing final delivery to be delayed after restarts.
- Preserve the core safety property that elapsed downtime should count across both `Warning` and `DeadMan` phases so expiration semantics are not undermined by outages.
- Make tests deterministic by avoiding hard-coded past timestamps in persisted-state tests.

### Description
- Change `load_or_initialize` in `crates/dead-man-switch/src/timer.rs` to compute `warning_duration` and `dead_man_duration`, derive an `(timer_type, duration, effective_elapsed)` triple from the persisted state, and reconstruct the monotonic `start` using `effective_elapsed` so residual elapsed time carries into `DeadMan` when appropriate.
- Clamp elapsed values using `saturating_sub` and `min` to avoid underflow and to bound applied elapsed time to the configured durations.
- Update an existing restore test to use the current wall-clock time and add a regression test `load_or_initialize_carries_elapsed_warning_time_into_dead_man` that asserts a `Warning` persisted at `now - 20s` with `warning=10s` and `deadman=5s` restores as an expired `DeadMan` timer.
- Run `cargo fmt` to ensure formatting is clean after the changes.

### Testing
- Ran `cargo fmt` successfully with no errors.
- Ran the targeted unit test with `cargo test -p dead-man-switch load_or_initialize_carries_elapsed_warning_time_into_dead_man` and the test passed. 
- The crate compiled as part of running the test suite and the new regression test passed, confirming the restored timer now preserves overrun time across phases.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f75ae8e04c8330b04563b3e70e8ff5)